### PR TITLE
Stabilize theory MI computation with symmetry and remove numba bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.24.4
 scipy>=1.13.0
 matplotlib>=3.7.0
-numba>=0.54.0,<=0.57.0
+numba>=0.54.0
 tqdm>=4.64.1
 simple-pid>=1.0.1
 mpl-scatter-density>=0.7.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "matplotlib>=3.7.0",
         "sympy",
         "tqdm>=4.64.1",
-        "numba>=0.54.0,<=0.57",
+        "numba>=0.54.0",
         "simple-pid>=1.0.1",
         "mpl-scatter-density>=0.7.0",
         "sphinx-rtd-theme>=1.2.2",


### PR DESCRIPTION
Hi @edsonportosilva,

I played around with different options to improve the reliability of the floating point comparison issue discussed in #27 while preserving speed (see #27 for more details.).

The dictionary solution below seems to be pretty robust (I didn't observe any failures... ). `round(abs(x) / 1e-14) * 1e-14` instead of abs(x) is done to avoid redundant computations where we only have a small floating point error.

In contrast to the existing implementation, the approach in this PR makes sure that we compute the contribution for all unique elements (even if slight differences remain in our list of "unique" elements, this would just lead to a few additional keys for which we'd have to evaluate the integral...)

![Screenshot 2025-03-25 at 15 26 39](https://github.com/user-attachments/assets/147a3942-6823-4d7c-b9bc-45ad298e8417)

![Screenshot 2025-03-25 at 15 16 24](https://github.com/user-attachments/assets/e4ebf7e2-8d26-404a-9dda-b9af032b6b03)

## Summary by Sourcery

Stabilize the theoryMI computation by addressing floating point comparison issues and ensuring contributions for all unique elements. Remove the upper version bound for numba in the project's dependencies to allow for more flexible version management.

Bug Fixes:
- Fix floating point comparison issue in theoryMI function by using a dictionary-based approach to handle unique elements.

Enhancements:
- Improve the theoryMI function by ensuring contributions are computed for all unique elements, enhancing reliability and performance.

Build:
- Remove the upper version bound for numba in requirements.txt and setup.py, allowing for greater flexibility in dependency management.