### PR TITLE
Rework the test suite and add a CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install OptiCommPy and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .
+          python -m pip install pytest
+
+      - name: Run test suite
+        run: pytest tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ optic/.vscode/settings.json
 /examples/.pylint.d
 /optic/dsp/__pycache__
 /optic/comm/__pycache__
+__pycache__/
+.pytest_cache/

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""
+Test functions in the optic.models.channels module.
+
+"""
+
+import numpy as np
+import pytest
+
+from optic.dsp.core import (
+    finddelay,
+    firFilter,
+    pulseShape,
+    signalPower,
+    upsample,
+)
+from optic.dsp.equalization import edc
+from optic.models.channels import awgn, linearFiberChannel, ssfm
+from optic.utils import parameters
+
+
+def awgnParams(snrdB, seed=0, complexNoise=True):
+    param = parameters()
+    param.snr = snrdB
+    param.Fs = 1
+    param.B = 1
+    param.seed = seed
+    param.complexNoise = complexNoise
+
+    return param
+
+
+class TestAWGN:
+    @pytest.mark.parametrize("snrdB", [5, 10, 20, 30])
+    def test_output_snr_matches_the_requested_value(self, snrdB):
+        # regression test: awgn() reads its configuration through
+        # getattr(param, "snr", 20), so it must be given a parameters object
+        rng = np.random.default_rng(0)
+        sig = rng.normal(size=200000) + 1j * rng.normal(size=200000)
+
+        noise = awgn(sig, awgnParams(snrdB)) - sig
+        measured = 10 * np.log10(signalPower(sig) / signalPower(noise))
+
+        assert measured == pytest.approx(snrdB, abs=0.1)
+
+    def test_noise_power_scales_with_the_oversampling_ratio(self):
+        rng = np.random.default_rng(1)
+        sig = rng.normal(size=100000) + 1j * rng.normal(size=100000)
+
+        param = awgnParams(20)
+        param.Fs, param.B = 4, 1
+
+        noise = awgn(sig, param) - sig
+        expected = 4 * signalPower(sig) / 10 ** (20 / 10)
+
+        assert signalPower(noise) == pytest.approx(expected, rel=0.02)
+
+    def test_is_reproducible_with_a_fixed_seed(self):
+        rng = np.random.default_rng(2)
+        sig = rng.normal(size=1000) + 1j * rng.normal(size=1000)
+
+        np.testing.assert_array_equal(
+            awgn(sig, awgnParams(15, seed=3)), awgn(sig, awgnParams(15, seed=3))
+        )
+
+    def test_real_valued_noise_leaves_a_real_signal_real(self):
+        rng = np.random.default_rng(4)
+        sig = rng.normal(size=10000)
+
+        out = awgn(sig, awgnParams(20, complexNoise=False))
+
+        assert np.isrealobj(out) or np.allclose(np.imag(out), 0.0)
+
+
+class TestLinearFiberChannel:
+    @pytest.mark.parametrize("L, alpha", [(50, 0.2), (100, 0.2), (80, 0.25)])
+    def test_attenuation_follows_the_fiber_loss_coefficient(self, L, alpha):
+        rng = np.random.default_rng(5)
+        sig = rng.normal(size=8192) + 1j * rng.normal(size=8192)
+
+        param = parameters()
+        param.L = L
+        param.alpha = alpha
+        param.D = 0  # isolate the loss from the dispersion
+        param.Fs = 64e9
+
+        out = linearFiberChannel(sig, param)
+        lossdB = 10 * np.log10(signalPower(sig) / signalPower(out))
+
+        assert lossdB == pytest.approx(alpha * L, rel=1e-6)
+
+    def test_dispersion_is_energy_preserving(self):
+        rng = np.random.default_rng(6)
+        sig = rng.normal(size=8192) + 1j * rng.normal(size=8192)
+
+        param = parameters()
+        param.L = 200
+        param.alpha = 0  # lossless, so only the dispersion acts
+        param.D = 16
+        param.Fs = 64e9
+
+        assert signalPower(linearFiberChannel(sig, param)) == pytest.approx(
+            signalPower(sig), rel=1e-9
+        )
+
+    @pytest.mark.parametrize("L", [100, 400])
+    def test_chromatic_dispersion_is_undone_by_edc(self, L):
+        SpS, Rs = 4, 32e9
+        Fs = SpS * Rs
+
+        rng = np.random.default_rng(7)
+        symbols = rng.choice([-1 - 1j, -1 + 1j, 1 - 1j, 1 + 1j], size=8192)
+
+        paramPulse = parameters()
+        paramPulse.pulseType = "rrc"
+        paramPulse.SpS = SpS
+        paramPulse.nFilterTaps = 1024
+        paramPulse.rollOff = 0.1
+        sig = firFilter(pulseShape(paramPulse), upsample(symbols, SpS))
+
+        paramCh = parameters()
+        paramCh.L = L
+        paramCh.alpha = 0
+        paramCh.D = 16
+        paramCh.Fc = 193.1e12
+        paramCh.Fs = Fs
+
+        paramEDC = parameters()
+        paramEDC.L = L
+        paramEDC.D = paramCh.D
+        paramEDC.Fc = paramCh.Fc
+        paramEDC.Fs = Fs
+        paramEDC.Rs = Rs
+
+        dispersed = linearFiberChannel(sig, paramCh)
+        recovered = edc(dispersed, paramEDC)
+
+        # realign before comparing: the block-wise FFT convolution used by edc()
+        # currently leaves a residual delay of a few samples
+        recovered = np.roll(recovered, finddelay(np.abs(sig), np.abs(recovered)))
+
+        guard = 2000
+        residual = signalPower(
+            recovered[guard:-guard] - sig[guard:-guard]
+        ) / signalPower(sig[guard:-guard])
+        uncompensated = signalPower(
+            dispersed[guard:-guard] - sig[guard:-guard]
+        ) / signalPower(sig[guard:-guard])
+
+        assert residual < 0.02
+        assert residual < uncompensated / 100
+
+
+class TestSSFM:
+    def test_reduces_to_the_linear_channel_when_the_nonlinearity_is_off(self):
+        rng = np.random.default_rng(8)
+        sig = 1e-3 * (rng.normal(size=4096) + 1j * rng.normal(size=4096))
+
+        paramSSFM = parameters()
+        paramSSFM.Ltotal = 80
+        paramSSFM.Lspan = 80
+        paramSSFM.hz = 1
+        paramSSFM.alpha = 0.2
+        paramSSFM.D = 16
+        paramSSFM.gamma = 0  # switch the Kerr nonlinearity off
+        paramSSFM.Fc = 193.1e12
+        paramSSFM.Fs = 64e9
+        paramSSFM.amp = None
+        paramSSFM.prgsBar = False
+
+        paramLin = parameters()
+        paramLin.L = paramSSFM.Ltotal
+        paramLin.alpha = paramSSFM.alpha
+        paramLin.D = paramSSFM.D
+        paramLin.Fc = paramSSFM.Fc
+        paramLin.Fs = paramSSFM.Fs
+
+        np.testing.assert_allclose(
+            ssfm(sig, paramSSFM), linearFiberChannel(sig, paramLin), atol=1e-12
+        )
+
+    def test_nonlinearity_broadens_the_signal_spectrum(self):
+        # self-phase modulation generates new spectral components
+        rng = np.random.default_rng(9)
+        sig = rng.normal(size=4096) + 1j * rng.normal(size=4096)
+
+        param = parameters()
+        param.Ltotal = 80
+        param.Lspan = 80
+        param.hz = 1
+        param.alpha = 0
+        param.D = 0  # isolate the SPM from the dispersion
+        param.Fc = 193.1e12
+        param.Fs = 64e9
+        param.amp = None
+        param.prgsBar = False
+
+        param.gamma = 0
+        spectrumLinear = np.abs(np.fft.fft(ssfm(sig, param)))
+
+        param.gamma = 1.3
+        spectrumNonlinear = np.abs(np.fft.fft(ssfm(sig, param)))
+
+        assert not np.allclose(spectrumLinear, spectrumNonlinear)
+
+    def test_preserves_the_signal_power_without_loss_or_amplification(self):
+        rng = np.random.default_rng(10)
+        sig = rng.normal(size=4096) + 1j * rng.normal(size=4096)
+
+        param = parameters()
+        param.Ltotal = 80
+        param.Lspan = 80
+        param.hz = 1
+        param.alpha = 0
+        param.D = 16
+        param.gamma = 1.3
+        param.Fc = 193.1e12
+        param.Fs = 64e9
+        param.amp = None
+        param.prgsBar = False
+
+        assert signalPower(ssfm(sig, param)) == pytest.approx(
+            signalPower(sig), rel=1e-9
+        )

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -1,29 +1,333 @@
 # -*- coding: utf-8 -*-
 """
-Test functions in optic.dsp.core module.
+Test functions in the optic.dsp.core module.
 
 """
 
 import numpy as np
+import pytest
 
-from optic.dsp.core import finddelay
+from optic.dsp.core import (
+    decimate,
+    delaySignal,
+    finddelay,
+    firFilter,
+    freqShift,
+    gaussianNoise,
+    lowPassFIR,
+    movingAverage,
+    phaseNoise,
+    pnorm,
+    pulseShape,
+    quantizer,
+    resample,
+    sigPow,
+    signalPower,
+    symbolSync,
+    upsample,
+)
+from optic.utils import parameters
 
 
-def test_finddelay_for_arrays_of_real_values():
-    delay = 35
+class TestFindDelay:
+    def test_finddelay_for_arrays_of_real_values(self):
+        delay = 35
 
-    a = np.arange(0, 100)
-    b = np.roll(a, -delay)
+        a = np.arange(0, 100)
+        b = np.roll(a, -delay)
 
-    assert delay == finddelay(a, b)
-    assert delay == -finddelay(b, a)
+        assert delay == finddelay(a, b)
+        assert delay == -finddelay(b, a)
+
+    def test_finddelay_for_arrays_of_complex_values(self):
+        delay = 57
+
+        a = np.arange(0, 100) + 1j * np.arange(0, 100)
+        b = np.roll(a, -delay)
+
+        assert delay == finddelay(a, b)
+        assert delay == -finddelay(b, a)
 
 
-def test_finddelay_for_arrays_of_complex_values():
-    delay = 57
+class TestPowerNormalization:
+    @pytest.mark.parametrize("nModes", [1, 2])
+    def test_pnorm_normalizes_the_average_power_per_sample(self, nModes):
+        rng = np.random.default_rng(0)
+        x = rng.normal(scale=3.0, size=(1000, nModes)) + 1j * rng.normal(
+            scale=3.0, size=(1000, nModes)
+        )
 
-    a = np.arange(0, 100) + 1j * np.arange(0, 100)
-    b = np.roll(a, -delay)
+        y = pnorm(x)
 
-    assert delay == finddelay(a, b)
-    assert delay == -finddelay(b, a)
+        assert np.mean(np.abs(y) ** 2) == pytest.approx(1.0)
+
+    def test_pnorm_preserves_the_power_ratio_between_modes(self):
+        rng = np.random.default_rng(10)
+        x = rng.normal(size=(1000, 2)) + 1j * rng.normal(size=(1000, 2))
+        x[:, 1] *= 2
+
+        y = pnorm(x)
+        powerIn = np.mean(np.abs(x) ** 2, axis=0)
+        powerOut = np.mean(np.abs(y) ** 2, axis=0)
+
+        assert powerOut[1] / powerOut[0] == pytest.approx(powerIn[1] / powerIn[0])
+
+    def test_signalPower_adds_up_the_power_of_all_modes(self):
+        x = np.ones((100, 2), dtype=complex)
+
+        assert signalPower(x) == pytest.approx(2.0)
+
+    def test_sigPow_returns_the_average_power_per_mode(self):
+        x = 2 * np.ones((100, 2), dtype=complex)
+
+        np.testing.assert_allclose(sigPow(x), 4.0)
+
+
+class TestFIRFiltering:
+    def test_firFilter_with_a_unit_impulse_returns_the_input_signal(self):
+        rng = np.random.default_rng(1)
+        x = rng.normal(size=256) + 1j * rng.normal(size=256)
+        h = np.array([0.0, 1.0, 0.0])
+
+        np.testing.assert_allclose(firFilter(h, x), x, atol=1e-12)
+
+    def test_firFilter_compensates_for_the_filter_delay(self):
+        # a symmetric filter must not shift the position of a smooth pulse
+        n = np.arange(201)
+        x = np.exp(-((n - 100) ** 2) / (2 * 5.0**2))
+        h = np.ones(11) / 11
+
+        y = firFilter(h, x)
+
+        assert np.argmax(np.abs(y)) == 100
+
+    def test_firFilter_matches_a_direct_convolution(self):
+        rng = np.random.default_rng(11)
+        x = rng.normal(size=512)
+        h = rng.normal(size=17)
+
+        np.testing.assert_allclose(
+            firFilter(h, x), np.convolve(x, h, mode="same"), atol=1e-10
+        )
+
+    def test_firFilter_handles_multimode_signals(self):
+        rng = np.random.default_rng(2)
+        x = rng.normal(size=(256, 2)) + 1j * rng.normal(size=(256, 2))
+        h = np.array([0.0, 1.0, 0.0])
+
+        y = firFilter(h, x)
+
+        assert y.shape == x.shape
+        np.testing.assert_allclose(y, x, atol=1e-12)
+
+
+class TestPulseShaping:
+    @pytest.mark.parametrize("pulseType", ["rect", "nrz", "rrc", "rc"])
+    def test_pulseShape_returns_coefficients_with_unit_dc_gain(self, pulseType):
+        param = parameters()
+        param.pulseType = pulseType
+        param.SpS = 8
+        param.nFilterTaps = 128
+
+        pulse = pulseShape(param)
+
+        assert pulse.size > 0
+        assert np.sum(pulse) == pytest.approx(1.0)
+
+    def test_rrc_pulse_satisfies_the_nyquist_criterion_after_matched_filtering(self):
+        # RRC * RRC = RC, which has zero crossings at all non-zero multiples of
+        # the symbol period, i.e. the cascade is free of intersymbol interference
+        SpS = 8
+        param = parameters()
+        param.pulseType = "rrc"
+        param.SpS = SpS
+        param.nFilterTaps = 4096
+        param.rollOff = 0.1
+
+        pulse = pulseShape(param)
+        rc = np.convolve(pulse, pulse)
+        rc = rc / np.max(np.abs(rc))
+
+        center = np.argmax(np.abs(rc))
+        offsets = SpS * np.arange(1, 10)
+
+        np.testing.assert_allclose(rc[center + offsets], 0.0, atol=1e-3)
+        np.testing.assert_allclose(rc[center - offsets], 0.0, atol=1e-3)
+
+
+class TestResampling:
+    @pytest.mark.parametrize("factor", [2, 4, 8])
+    def test_upsample_inserts_zeros_between_the_input_samples(self, factor):
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+
+        y = upsample(x, factor)
+
+        assert y.size == x.size * factor
+        np.testing.assert_allclose(y[::factor], x)
+        assert np.count_nonzero(y) == np.count_nonzero(x)
+
+    def test_decimate_reduces_the_number_of_samples_per_symbol(self):
+        rng = np.random.default_rng(3)
+        symbols = rng.normal(size=(500, 2)) + 1j * rng.normal(size=(500, 2))
+        sig = np.repeat(symbols, 8, axis=0)
+
+        param = parameters()
+        param.SpSin = 8
+        param.SpSout = 2
+
+        out = decimate(sig, param)
+
+        assert out.shape == (500 * 2, 2)
+
+    def test_resample_changes_the_sampling_rate_by_the_requested_ratio(self):
+        rng = np.random.default_rng(4)
+        sig = rng.normal(size=1024) + 1j * rng.normal(size=1024)
+
+        param = parameters()
+        param.inFs = 4
+        param.outFs = 2
+
+        assert resample(sig, param).size == 512
+
+
+class TestQuantizer:
+    # quantizer() indexes x.shape[1], so inputs must be 2D
+    @pytest.mark.parametrize("nBits", [2, 4, 6])
+    def test_quantizer_produces_at_most_two_to_the_nBits_levels(self, nBits):
+        x = np.linspace(-1, 1, 5000).reshape(-1, 1)
+
+        y = quantizer(x, nBits, 1, -1)
+
+        assert np.unique(y).size <= 2**nBits
+
+    def test_quantization_error_is_bounded_by_the_step_size(self):
+        nBits = 6
+        x = np.linspace(-1, 1, 5000).reshape(-1, 1)
+
+        y = quantizer(x, nBits, 1, -1)
+        step = (1 - (-1)) / (2**nBits - 1)
+
+        assert np.max(np.abs(y - x)) <= step / 2 + 1e-12
+
+    def test_quantizer_clips_the_input_to_the_full_scale_range(self):
+        x = np.array([[-5.0], [0.0], [5.0]])
+
+        y = quantizer(x, 8, 1, -1)
+
+        assert np.all(y >= -1) and np.all(y <= 1)
+
+
+class TestLowPassFIR:
+    def test_lowpass_filter_passes_dc_and_rejects_the_stopband(self):
+        fs, fc, N = 100.0, 10.0, 401
+
+        h = lowPassFIR(fc, fs, N, typeF="rect")
+        H = np.fft.rfft(h, 8192)
+        freq = np.fft.rfftfreq(8192, d=1 / fs)
+
+        gainDC = np.abs(H[0])
+        gainStop = np.max(np.abs(H[freq > 3 * fc]))
+
+        assert gainDC == pytest.approx(1.0, rel=0.05)
+        assert gainStop < 0.1 * gainDC
+
+
+class TestFrequencyShift:
+    def test_freqShift_moves_the_spectral_peak_to_the_expected_frequency(self):
+        Fs, N, deltaF = 1000.0, 4096, 100.0
+        x = np.ones(N, dtype=complex)
+
+        y = freqShift(x, deltaF, Fs)
+        freq = np.fft.fftfreq(N, d=1 / Fs)
+
+        assert freq[np.argmax(np.abs(np.fft.fft(y)))] == pytest.approx(
+            deltaF, abs=Fs / N
+        )
+
+    def test_shifting_forwards_and_backwards_restores_the_input(self):
+        rng = np.random.default_rng(5)
+        Fs = 1000.0
+        x = rng.normal(size=2048) + 1j * rng.normal(size=2048)
+
+        y = freqShift(freqShift(x, 137.0, Fs), -137.0, Fs)
+
+        np.testing.assert_allclose(y, x, atol=1e-9)
+
+
+class TestMovingAverage:
+    def test_moving_average_of_a_constant_signal_is_the_constant(self):
+        x = 3 * np.ones((100, 2))
+
+        # the first and last N//2 samples are affected by the zero padding
+        np.testing.assert_allclose(movingAverage(x, 5)[2:-2], 3.0)
+
+    def test_moving_average_matches_a_direct_convolution(self):
+        rng = np.random.default_rng(6)
+        N = 4
+        x = rng.normal(size=(64, 1))
+
+        expected = np.convolve(x[:, 0], np.ones(N) / N, mode="same")
+
+        np.testing.assert_allclose(movingAverage(x, N)[10:-10, 0], expected[10:-10])
+
+
+class TestDelaySignal:
+    @pytest.mark.parametrize("delay", [5, 10, 25])
+    def test_integer_sample_delay_matches_a_circular_shift(self, delay):
+        rng = np.random.default_rng(7)
+        x = rng.normal(size=1024)
+
+        y = delaySignal(x, delay, Fs=1)
+
+        assert y.size == x.size
+        np.testing.assert_allclose(
+            y[100:-100], np.roll(x, delay)[100:-100], atol=1e-9
+        )
+        assert finddelay(x, y) == -delay
+
+    def test_zero_delay_returns_the_input_signal(self):
+        rng = np.random.default_rng(8)
+        x = rng.normal(size=512)
+
+        # the very last sample is excluded: for delay = 0 no zero padding is
+        # added, so the internal np.roll(..., -1) correction drops it
+        np.testing.assert_allclose(delaySignal(x, 0, Fs=1)[:-1], x[:-1], atol=1e-9)
+
+
+class TestNoiseGeneration:
+    def test_gaussianNoise_has_the_requested_variance(self):
+        noise = gaussianNoise((200000,), 4.0, seed=42)
+
+        assert np.var(noise) == pytest.approx(4.0, rel=0.05)
+
+    def test_gaussianNoise_is_reproducible_with_a_fixed_seed(self):
+        a = gaussianNoise((1000,), 1.0, seed=123)
+        b = gaussianNoise((1000,), 1.0, seed=123)
+
+        np.testing.assert_array_equal(a, b)
+
+    def test_phaseNoise_increments_follow_the_laser_linewidth(self):
+        # random-walk phase noise has increments of variance 2*pi*lw*Ts
+        lw, Ts, N = 100e3, 1 / 32e9, 500000
+
+        pn = phaseNoise(lw, N, Ts, seed=11)
+
+        assert np.var(np.diff(pn)) == pytest.approx(2 * np.pi * lw * Ts, rel=0.05)
+
+    def test_phaseNoise_starts_at_zero_phase(self):
+        pn = phaseNoise(100e3, 1000, 1 / 32e9, seed=12)
+
+        assert pn[0] == pytest.approx(0.0)
+
+
+class TestSymbolSync:
+    def test_symbolSync_realigns_a_delayed_symbol_sequence(self):
+        rng = np.random.default_rng(9)
+        SpS = 2
+        symbTx = rng.choice([-1 - 1j, -1 + 1j, 1 - 1j, 1 + 1j], size=(2000, 1))
+        sigRx = np.roll(np.repeat(symbTx, SpS, axis=0), 17 * SpS, axis=0)
+
+        symbRx = symbolSync(sigRx, symbTx, SpS)
+
+        assert symbRx.shape == symbTx.shape
+        assert finddelay(np.abs(sigRx[::SpS, 0]), np.abs(symbRx[:, 0])) == 0

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+Check that every public module of the package can be imported.
+
+A missing or misspelled name in a module-level import statement makes the
+whole library unusable, so it is worth catching it explicitly.
+
+"""
+
+import importlib
+
+import pytest
+
+MODULES = [
+    "optic.utils",
+    "optic.plot",
+    "optic.comm.fec",
+    "optic.comm.metrics",
+    "optic.comm.modulation",
+    "optic.comm.ofdm",
+    "optic.comm.sources",
+    "optic.dsp.carrierRecovery",
+    "optic.dsp.clockRecovery",
+    "optic.dsp.core",
+    "optic.dsp.equalization",
+    "optic.dsp.synchronization",
+    "optic.models.amplification",
+    "optic.models.channels",
+    "optic.models.devices",
+    "optic.models.perturbation",
+    "optic.models.tx",
+]
+
+# modules that require CuPy and a CUDA-capable device
+GPU_MODULES = [
+    "optic.dsp.carrierRecoveryGPU",
+    "optic.dsp.coreGPU",
+    "optic.models.modelsGPU",
+]
+
+
+@pytest.mark.parametrize("moduleName", MODULES)
+def test_module_can_be_imported(moduleName):
+    assert importlib.import_module(moduleName) is not None
+
+
+@pytest.mark.parametrize("moduleName", GPU_MODULES)
+def test_gpu_module_can_be_imported(moduleName):
+    pytest.importorskip("cupy", reason="CuPy is not installed")
+
+    assert importlib.import_module(moduleName) is not None

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,91 +1,182 @@
-import unittest
+# -*- coding: utf-8 -*-
+"""
+Test functions in the optic.comm.metrics module.
+
+"""
 
 import numpy as np
+import pytest
 
-from optic.comm.metrics import (ASE_NyquistWDM, GN_Model_NyquistWDM,
-                                GNmodel_OSNR, Qfunc, calcEVM, calcLinOSNR,
-                                calcLLR, fastBERcalc, monteCarloGMI,
-                                monteCarloMI, theoryBER)
-from optic.comm.modulation import modulateGray
+from optic.comm.metrics import (
+    Qfunc,
+    calcEVM,
+    calcLLR,
+    fastBERcalc,
+    monteCarloGMI,
+    monteCarloMI,
+    theoryBER,
+)
+from optic.comm.modulation import grayMapping, modulateGray
 from optic.dsp.core import pnorm
 from optic.models.channels import awgn
+from optic.utils import dec2bitarray, parameters
 
 
-class TestCommunicationMetrics(unittest.TestCase):
-    
-    def setUp(self):
-        # Set up common parameters or fixtures if needed
-        pass
+def awgnSymbols(M, snrdB, nSymbols=100000, constType="qam", seed=0):
+    """Generate a reference symbol sequence and its noisy version."""
+    rng = np.random.default_rng(seed)
+    bits = rng.integers(0, 2, int(np.log2(M)) * nSymbols)
+    symbTx = pnorm(modulateGray(bits, M, constType))
 
-    def test_fastBERcalc(self):
-        # Add test cases for fastBERcalc
+    param = parameters()
+    param.snr = snrdB
+    param.Fs = 1
+    param.B = 1
+    param.seed = seed
 
-        # Run BER vs Ebn0 Monte Carlo simulation in the AWGN channel
+    return symbTx, awgn(symbTx, param)
 
-        qamOrder  = [4, 16, 64, 256]  # Modulation order
 
-        EbN0dB_  = np.arange(10, 25.5, 0.5)
-        BER      = np.zeros((len(EbN0dB_),len(qamOrder)))
-        BER_theory = np.zeros((len(EbN0dB_),len(qamOrder)))
+class TestFastBERcalc:
+    @pytest.mark.parametrize("M", [4, 16, 64])
+    def test_noiseless_transmission_gives_no_errors(self, M):
+        symbTx, _ = awgnSymbols(M, snrdB=40, nSymbols=10000)
 
-        for ii, M in enumerate(qamOrder):
-        
-            for indSNR in range(EbN0dB_.size):
+        with np.errstate(divide="ignore"):
+            BER, SER, SNR = fastBERcalc(symbTx, symbTx, M, "qam")
 
-                EbN0dB = EbN0dB_[indSNR]
+        assert BER[0] == 0.0
+        assert SER[0] == 0.0
+        assert SNR[0] > 100  # infinite up to floating-point round-off
 
-                # generate random bits
-                bitsTx = np.random.randint(2, size=int(np.log2(M)*1e5))    
+    @pytest.mark.parametrize(
+        "M, EbN0dB", [(4, 6), (16, 10), (64, 14)]
+    )
+    def test_measured_ber_follows_the_theoretical_curve(self, M, EbN0dB):
+        # awgn() reads its configuration from a parameters object; passing a
+        # bare float silently falls back to the default 20 dB SNR
+        snrdB = EbN0dB + 10 * np.log10(np.log2(M))
+        symbTx, symbRx = awgnSymbols(M, snrdB, nSymbols=100000, seed=M)
 
-                # Map bits to constellation symbols
-                symbTx = modulateGray(bitsTx, M, 'qam')
+        BER = fastBERcalc(symbRx, symbTx, M, "qam")[0][0]
 
-                # Normalize symbols energy to 1
-                symbTx = pnorm(symbTx) 
+        assert BER == pytest.approx(theoryBER(M, EbN0dB, "qam"), rel=0.2)
 
-                # AWGN channel  
-                snrdB  = EbN0dB + 10*np.log10(np.log2(M))
-                symbRx = awgn(symbTx, snrdB)
+    @pytest.mark.parametrize("M", [4, 16])
+    def test_ber_decreases_monotonically_with_the_snr(self, M):
+        BER = [
+            fastBERcalc(*reversed(awgnSymbols(M, snrdB, 50000, seed=1)), M, "qam")[0][0]
+            for snrdB in [8, 11, 14, 17]
+        ]
 
-                # BER calculation
-                BER[indSNR, ii] = fastBERcalc(symbRx, symbTx, M, 'qam')[0][0]
-                BER_theory[indSNR, ii] = theoryBER(M, EbN0dB, 'qam')
+        assert np.all(np.diff(BER) <= 0)
 
-                if BER[indSNR, ii] == 0:              
-                    break
+    @pytest.mark.parametrize("snrdB", [10, 15, 20])
+    def test_estimated_snr_matches_the_channel_snr(self, snrdB):
+        # the estimate carries a small positive bias at low SNR, since the
+        # received symbols are power-normalized and phase-corrected first
+        symbTx, symbRx = awgnSymbols(16, snrdB, nSymbols=100000, seed=7)
 
-        np.testing.assert_array_almost_equal(BER, BER_theory, decimal=3)      
-   
-    def test_monteCarlo_MI_and_GMI(self):
-        # Run GMI vs SNR Monte Carlo simulation
-        qamOrder  = [4, 16, 64]  # Modulation order
+        SNR = fastBERcalc(symbRx, symbTx, 16, "qam")[2][0]
 
-        SNR  = np.arange(15, 26, 1)
-        MI  = np.zeros((len(SNR),len(qamOrder)))
-        GMI  = np.zeros((len(SNR),len(qamOrder)))
+        assert SNR == pytest.approx(snrdB, abs=0.5)
 
-        for ii, M in enumerate(qamOrder):            
-            for indSNR in range(SNR.size):
 
-                snrdB = SNR[indSNR]
+class TestTheoryBER:
+    @pytest.mark.parametrize("constType", ["qam", "psk", "pam"])
+    @pytest.mark.parametrize("M", [4, 16])
+    def test_theoretical_ber_decreases_with_the_snr_per_bit(self, M, constType):
+        BER = [theoryBER(M, EbN0dB, constType) for EbN0dB in range(2, 16, 2)]
 
-                # generate random bits
-                bitsTx   = np.random.randint(2, size=int(np.log2(M)*1e5))    
+        assert np.all(np.diff(BER) < 0)
+        assert np.all(np.array(BER) >= 0)
 
-                # Map bits to constellation symbols
-                symbTx = modulateGray(bitsTx, M, 'qam')
+    def test_higher_order_qam_needs_more_energy_per_bit(self):
+        assert theoryBER(4, 10, "qam") < theoryBER(16, 10, "qam")
+        assert theoryBER(16, 10, "qam") < theoryBER(64, 10, "qam")
 
-                # Normalize symbols energy to 1
-                symbTx = pnorm(symbTx) 
 
-                # AWGN channel       
-                symbRx = awgn(symbTx, snrdB)
+class TestQfunc:
+    def test_reference_values(self):
+        assert Qfunc(0) == pytest.approx(0.5)
+        assert Qfunc(1) == pytest.approx(0.158655, abs=1e-6)
+        assert Qfunc(3) == pytest.approx(1.349898e-3, rel=1e-5)
 
-                # GMI estimation
-                MI[indSNR, ii] = monteCarloMI(symbRx, symbTx, M, 'qam')[0]
-                GMI[indSNR, ii] = monteCarloGMI(symbRx, symbTx, M, 'qam')[0][0]
+    def test_is_symmetric_about_zero(self):
+        for x in [0.5, 1.0, 2.0, 4.0]:
+            assert Qfunc(x) + Qfunc(-x) == pytest.approx(1.0)
 
-        np.testing.assert_array_almost_equal(MI, GMI, decimal=1)        
-   
-if __name__ == '__main__':
-    unittest.main()
+
+class TestCalcEVM:
+    def test_evm_of_a_perfect_signal_is_zero(self):
+        symbTx, _ = awgnSymbols(16, snrdB=40, nSymbols=10000)
+
+        np.testing.assert_allclose(calcEVM(symbTx, 16, "qam", symbTx), 0.0, atol=1e-12)
+
+    @pytest.mark.parametrize("snrdB", [15, 20, 25])
+    def test_evm_tracks_the_error_to_signal_power_ratio(self, snrdB):
+        # calcEVM returns mean(|error|^2)/mean(|reference|^2), i.e. the squared
+        # error vector magnitude, which equals 1/SNR for an AWGN channel
+        symbTx, symbRx = awgnSymbols(16, snrdB, nSymbols=100000, seed=3)
+
+        EVM = calcEVM(symbRx, 16, "qam", symbTx)[0]
+
+        assert EVM == pytest.approx(10 ** (-snrdB / 10), rel=0.1)
+
+
+class TestInformationRates:
+    @pytest.mark.parametrize("M", [4, 16])
+    def test_gmi_approaches_the_number_of_bits_per_symbol_at_high_snr(self, M):
+        symbTx, symbRx = awgnSymbols(M, snrdB=30, nSymbols=50000, seed=5)
+
+        GMI, NGMI = monteCarloGMI(symbRx, symbTx, M, "qam")
+
+        assert GMI[0] == pytest.approx(np.log2(M), rel=1e-3)
+        assert NGMI[0] == pytest.approx(1.0, rel=1e-3)
+
+    @pytest.mark.parametrize("M", [4, 16])
+    def test_gmi_and_mi_agree_for_gray_mapped_constellations(self, M):
+        symbTx, symbRx = awgnSymbols(M, snrdB=18, nSymbols=50000, seed=6)
+
+        GMI = monteCarloGMI(symbRx, symbTx, M, "qam")[0][0]
+        MI = monteCarloMI(symbRx, symbTx, M, "qam")[0]
+
+        assert GMI == pytest.approx(MI, abs=0.1)
+
+    @pytest.mark.parametrize("M", [4, 16])
+    def test_information_rates_increase_with_the_snr(self, M):
+        GMI = [
+            monteCarloGMI(*reversed(awgnSymbols(M, snrdB, 20000, seed=8)), M, "qam")[0][
+                0
+            ]
+            for snrdB in [5, 10, 15, 20]
+        ]
+
+        assert np.all(np.diff(GMI) > 0)
+
+
+class TestCalcLLR:
+    def test_llr_sign_follows_the_log_p0_over_p1_convention(self):
+        M = 4
+        const = grayMapping(M, "qam").flatten()
+        bitMap = dec2bitarray(np.arange(M), int(np.log2(M)))
+        px = np.ones(M) / M
+
+        for indSymb in range(M):
+            llr = calcLLR(np.array([const[indSymb]]), 0.01, const, bitMap, px)
+
+            # a positive LLR means the bit is more likely to be 0
+            np.testing.assert_array_equal(llr < 0, bitMap[indSymb].astype(bool))
+
+    def test_llr_magnitude_grows_as_the_noise_decreases(self):
+        M = 4
+        const = grayMapping(M, "qam").flatten()
+        bitMap = dec2bitarray(np.arange(M), int(np.log2(M)))
+        px = np.ones(M) / M
+
+        reliability = [
+            np.mean(np.abs(calcLLR(const[:1], σ2, const, bitMap, px)))
+            for σ2 in [1.0, 0.5, 0.1, 0.01]
+        ]
+
+        assert np.all(np.diff(reliability) > 0)

--- a/tests/test_modulation.py
+++ b/tests/test_modulation.py
@@ -1,60 +1,188 @@
-import unittest
+# -*- coding: utf-8 -*-
+"""
+Test functions in the optic.comm.modulation module.
+
+"""
 
 import numpy as np
+import pytest
 
-from optic.comm.modulation import (demap, demodulateGray, grayCode,
-                                   grayMapping, minEuclid, modulateGray)
+from optic.comm.modulation import (
+    demap,
+    demodulateGray,
+    detector,
+    grayCode,
+    grayMapping,
+    minEuclid,
+    modulateGray,
+    pamConst,
+    pskConst,
+    qamConst,
+)
 from optic.utils import bitarray2dec, dec2bitarray
 
 
-class TestModulationFunctions(unittest.TestCase):
-    def test_GrayCode(self):
-        # Test GrayCode function for different values of n
-        for n in range(1, 6):
-            with self.subTest(n=n):
-                result = grayCode(n)
-                self.assertEqual(len(result), 2**n)
-                self.assertEqual(len(result[0]), n)
+class TestGrayCode:
+    @pytest.mark.parametrize("n", [1, 2, 3, 4, 5])
+    def test_grayCode_returns_all_codewords_of_the_requested_width(self, n):
+        code = grayCode(n)
 
-    def test_GrayMapping(self):
-        # Test GrayMapping function for different values of M and constType
-        M_values = [4, 16, 64]
-        constTypes = ['qam', 'psk', 'pam']
-        for M in M_values:
-            for constType in constTypes:
-                with self.subTest(M=M, constType=constType):
-                    result = grayMapping(M, constType)
-                    self.assertEqual(len(result), M)
+        assert len(code) == 2**n
+        assert all(len(word) == n for word in code)
+        assert len(set(code)) == 2**n
 
-    def test_minEuclid(self):
-        # Test minEuclid function with some example inputs
-        symb = np.array([1+1j, 2+2j, 3+3j])
-        const = np.array([1+1j, 3+3j, 2+2j])
-        result = minEuclid(symb, const)
-        np.testing.assert_array_equal(result, np.array([0, 2, 1]))
+    @pytest.mark.parametrize("n", [1, 2, 3, 4, 5])
+    def test_consecutive_codewords_differ_in_a_single_bit(self, n):
+        code = grayCode(n)
 
-    def test_demap(self):
-        # Test demap function with some example inputs
+        for current, following in zip(code, code[1:]):
+            assert sum(a != b for a, b in zip(current, following)) == 1
+
+
+class TestConstellations:
+    @pytest.mark.parametrize("M", [4, 16, 64])
+    @pytest.mark.parametrize("constType", ["qam", "psk", "pam"])
+    def test_grayMapping_returns_M_symbols(self, M, constType):
+        assert grayMapping(M, constType).size == M
+
+    def test_grayMapping_rejects_qam_orders_that_are_not_square(self):
+        with pytest.raises(ValueError):
+            grayMapping(2, "qam")
+
+    @pytest.mark.parametrize("M", [4, 16, 64])
+    def test_pskConst_symbols_lie_on_the_unit_circle(self, M):
+        np.testing.assert_allclose(np.abs(pskConst(M)), 1.0)
+
+    @pytest.mark.parametrize("M", [2, 4, 16])
+    def test_pamConst_symbols_are_real_and_equally_spaced(self, M):
+        const = np.sort(np.real(pamConst(M)).flatten())
+
+        np.testing.assert_allclose(np.imag(pamConst(M)), 0.0)
+        np.testing.assert_allclose(np.diff(const), np.diff(const)[0])
+
+    @pytest.mark.parametrize("M", [4, 16, 64])
+    def test_qamConst_is_a_square_grid_symmetric_about_the_origin(self, M):
+        const = qamConst(M).flatten()
+
+        assert const.size == M
+        assert np.unique(np.round(np.real(const), 9)).size == int(np.sqrt(M))
+        assert np.unique(np.round(np.imag(const), 9)).size == int(np.sqrt(M))
+        assert np.sum(const) == pytest.approx(0.0)
+
+    def test_ook_constellation_always_has_two_levels(self):
+        const = grayMapping(2, "ook").flatten()
+
+        assert const.size == 2
+        np.testing.assert_allclose(np.sort(np.real(const)), [0.0, 1.0])
+
+
+class TestSymbolMapping:
+    def test_minEuclid_returns_the_index_of_the_closest_symbol(self):
+        symb = np.array([1 + 1j, 2 + 2j, 3 + 3j])
+        const = np.array([1 + 1j, 3 + 3j, 2 + 2j])
+
+        np.testing.assert_array_equal(minEuclid(symb, const), np.array([0, 2, 1]))
+
+    def test_minEuclid_is_robust_to_small_perturbations(self):
+        rng = np.random.default_rng(0)
+        const = grayMapping(16, "qam").flatten()
+        indices = rng.integers(0, 16, 200)
+        symb = const[indices] + 1e-3 * rng.normal(size=200)
+
+        np.testing.assert_array_equal(minEuclid(symb, const), indices)
+
+    def test_demap_converts_symbol_indices_into_bit_sequences(self):
         indSymb = np.array([0, 2, 1])
         bitMap = np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
-        result = demap(indSymb, bitMap)
-        np.testing.assert_array_equal(result, np.array([0, 0, 1, 0, 0, 1]))
 
-    def test_modulateGray(self):
-        # Test modulateGray function with some example inputs
-        bits = np.array([0, 1, 0, 0, 1, 0])
-        M = 4
-        constType = 'qam'
-        result = modulateGray(bits, M, constType)
-        self.assertEqual(len(result), len(bits) // int(np.log2(M)))
+        np.testing.assert_array_equal(
+            demap(indSymb, bitMap), np.array([0, 0, 1, 0, 0, 1])
+        )
 
-    def test_demodulateGray(self):
-        # Test demodulateGray function with some example inputs
-        symb = np.array([1+1j, 3+3j, 2+2j])
-        M = 4
-        constType = 'qam'
-        result = demodulateGray(symb, M, constType)
-        self.assertEqual(len(result), len(symb) * int(np.log2(M)))
+    def test_demap_is_consistent_with_the_bit_to_decimal_helpers(self):
+        bitMap = dec2bitarray(np.arange(8), 3)
+        indSymb = np.array([5, 2, 7])
 
-if __name__ == '__main__':
-    unittest.main()
+        bits = demap(indSymb, bitMap).reshape(-1, 3)
+
+        assert [bitarray2dec(row) for row in bits] == [5, 2, 7]
+
+
+class TestModulateDemodulate:
+    @pytest.mark.parametrize("M", [4, 16, 64])
+    @pytest.mark.parametrize("constType", ["qam", "psk", "pam"])
+    def test_modulation_and_demodulation_are_lossless_without_noise(
+        self, M, constType
+    ):
+        bitsPerSymbol = int(np.log2(M))
+        rng = np.random.default_rng(1)
+        bits = rng.integers(0, 2, 500 * bitsPerSymbol)
+
+        symb = modulateGray(bits, M, constType)
+        recovered = demodulateGray(symb, M, constType)
+
+        assert symb.size == bits.size // bitsPerSymbol
+        np.testing.assert_array_equal(recovered, bits)
+
+    @pytest.mark.parametrize("M", [4, 16])
+    def test_modulateGray_only_produces_constellation_symbols(self, M):
+        rng = np.random.default_rng(2)
+        bits = rng.integers(0, 2, 400 * int(np.log2(M)))
+
+        symb = modulateGray(bits, M, "qam")
+
+        assert np.all(np.isin(symb, grayMapping(M, "qam").flatten()))
+
+    @pytest.mark.parametrize("constType", ["qam", "psk"])
+    def test_nearest_neighbour_symbols_differ_in_a_single_bit(self, constType):
+        # defining property of Gray mapping: the closest constellation symbols
+        # differ in exactly one bit, so most symbol errors cost a single bit
+        M = 16
+        bitsPerSymbol = int(np.log2(M))
+        const = grayMapping(M, constType).flatten()
+        bitMap = dec2bitarray(np.arange(M), bitsPerSymbol)
+
+        distances = np.abs(const[:, None] - const[None, :])
+        np.fill_diagonal(distances, np.inf)
+        minDistance = np.min(distances)
+
+        for i in range(M):
+            neighbours = np.flatnonzero(
+                np.isclose(distances[i], minDistance, rtol=1e-6)
+            )
+            for j in neighbours:
+                assert np.sum(bitMap[i] != bitMap[j]) == 1
+
+
+class TestDetector:
+    @pytest.mark.parametrize("rule", ["MAP", "ML"])
+    def test_detector_recovers_the_transmitted_symbols_at_high_snr(self, rule):
+        rng = np.random.default_rng(3)
+        const = grayMapping(16, "qam").flatten()
+        indices = rng.integers(0, 16, 500)
+        r = const[indices] + 1e-3 * (
+            rng.normal(size=500) + 1j * rng.normal(size=500)
+        )
+
+        decided, indDec = detector(r, 1e-6, const, rule=rule)
+
+        np.testing.assert_array_equal(indDec, indices)
+        np.testing.assert_allclose(decided, const[indices])
+
+    def test_map_and_ml_agree_for_uniform_priors(self):
+        rng = np.random.default_rng(4)
+        const = grayMapping(4, "qam").flatten()
+        r = const[rng.integers(0, 4, 200)] + 0.1 * rng.normal(size=200)
+
+        decidedMAP, _ = detector(r, 0.1, const, rule="MAP")
+        decidedML, _ = detector(r, 0.1, const, rule="ML")
+
+        np.testing.assert_allclose(decidedMAP, decidedML)
+
+    def test_map_detection_favours_symbols_with_a_higher_prior(self):
+        const = np.array([-1.0 + 0j, 1.0 + 0j])
+        r = np.array([0.05 + 0j])  # slightly closer to +1
+
+        decided, _ = detector(r, 1.0, const, px=np.array([0.99, 0.01]), rule="MAP")
+
+        assert decided[0].real == pytest.approx(-1.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+Test functions in the optic.utils module.
+
+"""
+
+import numpy as np
+import pytest
+
+from optic.utils import (
+    bitarray2dec,
+    ber2Qfactor,
+    dB2lin,
+    dBm2W,
+    dec2bitarray,
+    dotNumba,
+    lin2dB,
+    llr2bitProb,
+    parameters,
+)
+
+
+class TestParameters:
+    def test_attributes_can_be_set_and_read(self):
+        param = parameters()
+        param.Fs = 32e9
+        param.M = 16
+
+        assert param.Fs == 32e9
+        assert param.M == 16
+
+    def test_copy_returns_an_independent_object(self):
+        param = parameters()
+        param.values = np.array([1.0, 2.0, 3.0])
+        param.M = 16
+
+        paramCopy = param.copy()
+        paramCopy.M = 64
+        paramCopy.values[0] = 99.0
+
+        assert param.M == 16
+        assert param.values[0] == 1.0
+
+
+class TestUnitConversions:
+    @pytest.mark.parametrize("x", [1e-3, 0.5, 1.0, 2.0, 1e3])
+    def test_lin2dB_and_dB2lin_are_inverse_operations(self, x):
+        assert dB2lin(lin2dB(x)) == pytest.approx(x)
+
+    @pytest.mark.parametrize(
+        "dBm, watts", [(-30, 1e-6), (0, 1e-3), (10, 1e-2), (30, 1.0)]
+    )
+    def test_dBm2W_converts_reference_values(self, dBm, watts):
+        assert dBm2W(dBm) == pytest.approx(watts)
+
+    def test_ber2Qfactor_is_consistent_with_the_gaussian_approximation(self):
+        # BER = 0.5*erfc(Q/sqrt(2)), with Q returned in dB by ber2Qfactor
+        from scipy.special import erfc
+
+        for ber in [1e-2, 1e-3, 1e-5, 1e-9]:
+            Q = dB2lin(ber2Qfactor(ber))
+            assert 0.5 * erfc(Q / np.sqrt(2)) == pytest.approx(ber, rel=1e-6)
+
+    def test_ber2Qfactor_decreases_with_increasing_ber(self):
+        Q = [ber2Qfactor(ber) for ber in [1e-9, 1e-6, 1e-3, 1e-2]]
+        assert np.all(np.diff(Q) < 0)
+
+
+class TestBitArrayConversions:
+    @pytest.mark.parametrize("bit_width", [1, 4, 8, 16])
+    def test_dec2bitarray_and_bitarray2dec_are_inverse_operations(self, bit_width):
+        for x in range(2**bit_width):
+            bits = dec2bitarray(x, bit_width)
+
+            assert len(bits) == bit_width
+            assert bitarray2dec(bits) == x
+
+    def test_dec2bitarray_handles_arrays_of_decimals(self):
+        bits = dec2bitarray(np.array([0, 1, 2, 3]), 2)
+
+        np.testing.assert_array_equal(
+            bits, np.array([[0, 0], [0, 1], [1, 0], [1, 1]])
+        )
+
+    def test_dec2bitarray_uses_msb_first_ordering(self):
+        np.testing.assert_array_equal(dec2bitarray(1, 4), np.array([0, 0, 0, 1]))
+        np.testing.assert_array_equal(dec2bitarray(8, 4), np.array([1, 0, 0, 0]))
+
+
+class TestDotNumba:
+    def test_matches_numpy_dot_for_real_arrays(self):
+        a = np.arange(1.0, 6.0)
+        b = np.arange(5.0, 0.0, -1.0)
+
+        assert dotNumba(a, b) == pytest.approx(np.dot(a, b))
+
+    def test_matches_numpy_dot_for_complex_arrays(self):
+        rng = np.random.default_rng(42)
+        a = rng.normal(size=16) + 1j * rng.normal(size=16)
+        b = rng.normal(size=16) + 1j * rng.normal(size=16)
+
+        assert dotNumba(a, b) == pytest.approx(np.dot(a, b))
+
+
+class TestLLR2BitProb:
+    def test_matches_the_logistic_function(self):
+        llr = np.linspace(-20, 20, 41).reshape(-1, 1)
+
+        np.testing.assert_allclose(
+            llr2bitProb(llr, np.float64), 1 / (1 + np.exp(llr)), rtol=1e-12
+        )
+
+    def test_zero_llr_maps_to_equiprobable_bits(self):
+        np.testing.assert_allclose(llr2bitProb(np.zeros((4, 2))), 0.5)
+
+    def test_probabilities_decrease_with_increasing_llr(self):
+        # LLRs follow the log(P(b=0)/P(b=1)) convention, so P(b=1) decreases
+        probs = llr2bitProb(np.linspace(-10, 10, 21).reshape(-1, 1)).flatten()
+
+        assert np.all(np.diff(probs) < 0)
+
+    def test_is_numerically_stable_for_large_magnitude_llrs(self):
+        # a naive 1/(1 + exp(llr)) implementation overflows here
+        llr = np.array([[-1e4, -800.0, 0.0, 800.0, 1e4]])
+        probs = llr2bitProb(llr)
+
+        assert np.all(np.isfinite(probs))
+        assert np.all((probs >= 0) & (probs <= 1))
+        np.testing.assert_allclose(probs[0, :2], 1.0)
+        np.testing.assert_allclose(probs[0, 3:], 0.0)
+
+    def test_preserves_the_shape_of_the_input(self):
+        assert llr2bitProb(np.zeros((32, 4))).shape == (32, 4)


### PR DESCRIPTION
Following up on your suggestion in #34 — this reworks the test suite and adds a CI workflow.

## Why

`tests/test_metrics.py::test_fastBERcalc` was failing on `main`. It calls

```python
symbRx = awgn(symbTx, snrdB)
```

passing a float, while `awgn()` reads its configuration through `getattr(param, "snr", 20)`. The SNR therefore silently fell back to the 20 dB default and the measured BER no longer followed the `EbN0` values being swept, so it could never match `theoryBER()`. Building a proper `parameters` object makes the measured curve match the theory to within 20%.

The rest of the suite mixed `unittest` and `pytest` styles and covered only a handful of functions, so I extended it while I was there.

## What is in this PR

| File | Contents |
|---|---|
| `tests/test_utils.py` | new — unit conversions, bit array helpers, `dotNumba`, `llr2bitProb` (including its numerical stability for very large LLRs) |
| `tests/test_dsp.py` | extended — `pnorm`, `signalPower`, `sigPow`, `firFilter`, `pulseShape`, `upsample`, `decimate`, `resample`, `quantizer`, `lowPassFIR`, `freqShift`, `movingAverage`, `delaySignal`, `gaussianNoise`, `phaseNoise`, `symbolSync` |
| `tests/test_modulation.py` | ported to pytest and extended — constellation generators, `detector`, and the Gray mapping property that nearest-neighbour symbols differ in a single bit |
| `tests/test_metrics.py` | AWGN setup fixed, ported to pytest, plus `theoryBER`, `Qfunc`, `calcEVM`, `calcLLR` and the GMI/MI estimators |
| `tests/test_channels.py` | new — `awgn`, `linearFiberChannel`, its inversion by `edc`, and the reduction of `ssfm` to the linear channel for `gamma = 0` |
| `tests/test_imports.py` | new — every module must import; GPU modules are skipped when CuPy is missing |
| `.github/workflows/tests.yml` | new — pytest on Python 3.10–3.13 for pushes to `main` and pull requests |

Wherever possible the assertions check a property rather than a hardcoded number: RRC pulses are verified through the Nyquist criterion after matched filtering, `linearFiberChannel` through the fiber loss coefficient and energy conservation, `phaseNoise` through the variance of its increments, `awgn` through the SNR measured at its output. Random number generators are seeded, and the whole suite runs in about 12 s (182 tests, 3 skipped without a GPU).

`tests/test_imports.py` exists specifically because of #34: an import of a name that does not exist leaves the whole package unusable, and running it in CI makes that visible immediately.

## Things I noticed while writing the tests

None of these are addressed here, since they are outside the scope of a test PR. Happy to open issues or separate PRs for any of them.

1. **`edc()` shifts the signal by one sample.** Compensating 200 km of dispersion on an RRC-shaped QPSK signal leaves a normalized MSE of 2.1e-1; realigning the output by a single sample brings it down to 5.8e-3. The offset comes from `blockwiseFFTConv()` — `delaySignal()` works around the same effect with `np.roll(delayedSig, -1)`, but `edc()` does not. In a full receiver the adaptive equalizer absorbs it, which is probably why it went unnoticed. The test aligns the sequences before comparing, so it passes either way.

2. **`delaySignal(sig, 0)` corrupts the last sample.** With `delay = 0` there is no zero padding, so the final `np.roll(..., -1)` shifts a sample out of the signal. Delays greater than zero are unaffected.

3. **`pnorm()` docstring does not match its behaviour.** It says the average power of *each component* is normalized, but the implementation is `x / sqrt(mean(x * conj(x)))`, where the mean runs over the whole array. For a dual-polarization signal the total average power becomes 1 per sample rather than 1 per mode. The behaviour looks intentional — it preserves the power ratio between polarizations — so this may just be a documentation fix.

4. **`calcEVM()` returns the squared EVM.** It computes `mean(|error|^2) / mean(|reference|^2)`, whereas EVM is usually reported as the square root of that ratio. The example notebooks print the returned value as a percentage, so the reported figure is currently the error power ratio, not the RMS EVM.

5. **Two deprecated imports that will eventually break.** `optic/plot.py` imports `gaussian_filter` from `scipy.ndimage.filters`, a namespace scheduled for removal in SciPy 2.0, and `optic/models/amplification.py` imports `numpy.matlib`, deprecated since NumPy 1.19. Both currently emit warnings.

6. **`quantizer()` only accepts 2D arrays**, since it indexes `x.shape[1]`. Every internal caller reshapes first, so this is just worth a note in the docstring.
